### PR TITLE
Update gradle/gradle-build-action action to v2.2.2 (#102)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,14 +48,14 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Check_debug
-        uses: gradle/gradle-build-action@v2.2.1
+        uses: gradle/gradle-build-action@v2.2.2
         with:
-          arguments: lintAnalyzeDebug
+          arguments: lintAnalyzeDebug --warning-mode all
 
       - name: Check_release
-        uses: gradle/gradle-build-action@v2.2.1
+        uses: gradle/gradle-build-action@v2.2.2
         with:
-          arguments: lintAnalyzeRelease
+          arguments: lintAnalyzeRelease --warning-mode all
 
   build_debug:
     name: Build_Debug
@@ -76,7 +76,7 @@ jobs:
           java-version: 17
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.2.1
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: assembleDebug
 
@@ -117,7 +117,7 @@ jobs:
           java-version: 17
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.2.1
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: assembleRelease
 

--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -22,6 +22,6 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Show Gradle tasks
-        uses: gradle/gradle-build-action@v2.2.1
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: tasks --all


### PR DESCRIPTION
* Update gradle/gradle-build-action action to v2.2.2

* Create tasks.yml

* Show deprecated API in check

Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
Co-authored-by: qhy040404 <45379733+qhy040404@users.noreply.github.com>